### PR TITLE
Create password reset component, email confirmation container, and pa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Then in the root directory of the project run this:
 
 Windows:
 
+`rmdir "%cd%/client/node_modules/models"`
+
+`rmdir "%cd%/client/node_modules/@types/models"`
+
 `mklink /D "%cd%/client/node_modules/models" "%cd%/server/build/models"`
 
 `mklink /D "%cd%/client/node_modules/@types/models" "%cd%/server/build/types/models"`

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,7 +5,11 @@ import CssBaseline from '@mui/material/CssBaseline';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import PostDashboard from './containers/PostDashboard';
-import { AuthContainer } from './containers';
+import {
+  AuthContainer,
+  EmailConfirmContainer,
+  PassResetContainer,
+} from './containers';
 import './App.css';
 
 import { User } from 'models/user';
@@ -79,6 +83,8 @@ function App() {
         <Routes>
           <Route path='/' element={<AuthContainer />} />
           <Route path='/dashboard' element={<ProtectedRoute />} />
+          <Route path='/confirm-account' element={<EmailConfirmContainer />} />
+          <Route path='/password-reset' element={<PassResetContainer />} />
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/client/src/components/PassReset.tsx
+++ b/client/src/components/PassReset.tsx
@@ -5,39 +5,27 @@ import Avatar from '@mui/material/Avatar';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 
-import { useNavigate, useLocation } from 'react-router-dom';
-
 import ServerApi from '../api/v1/index';
 
-function SignIn(props: { handleChange: Function; showAlert: Function }) {
+function PassReset(props: { handleChange: Function; showAlert: Function }) {
   const api = new ServerApi();
 
-  const navigate = useNavigate();
-  const location = useLocation();
-
-  const previousPath = location.state?.from?.pathname || '/dashboard';
-
-  // create hooks for username and password
-  const [signinForm, setSignInForm] = useState({
-    userName: '',
-    password: '',
+  const [passResetForm, setPassResetForm] = useState({
+    email: '',
   });
 
-  const [signinFormErrors, setSignInFormErrors] = useState({
-    userName: '',
-    password: '',
+  const [passResetFormErrors, setPassResetFormErrors] = useState({
+    email: '',
   });
 
   const isFormMissingFields = () => {
-    for (const key in signinForm) {
-      if (signinForm[key as keyof typeof signinForm] === '') {
+    for (const key in passResetForm) {
+      if (passResetForm[key as keyof typeof passResetForm] === '') {
         return true;
       }
     }
@@ -46,8 +34,8 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
 
   const getErrorMessages = () => {
     let msg = '';
-    for (const key in signinFormErrors) {
-      const err = signinFormErrors[key as keyof typeof signinFormErrors];
+    for (const key in passResetFormErrors) {
+      const err = passResetFormErrors[key as keyof typeof passResetFormErrors];
       msg += err === '' ? err : `${err}.\n`;
     }
     msg = msg.slice(0, -1);
@@ -67,8 +55,6 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
     setHook: Function,
     errorMessage: string
   ) => {
-    // only check for the confirm password field
-
     if (!regexPattern.test(checkString)) {
       setHook(errorMessage);
     } else {
@@ -76,7 +62,6 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
     }
   };
 
-  // handle function for submitting username and password
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault(); // no refresh; default
 
@@ -95,7 +80,7 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
     }
 
     try {
-      const { status, data } = await api.signIn(signinForm);
+      const { status, data } = await api.requestPasswordReset(passResetForm);
       if (status !== 204) {
         if (!data) {
           throw new Error('Missing error response.');
@@ -104,7 +89,7 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
         console.error(msg);
         props.showAlert('error', msg);
       } else {
-        navigate(previousPath, { replace: true });
+        props.showAlert('success', 'Password reset email sent!');
       }
     } catch (error) {
       console.error(error);
@@ -116,21 +101,21 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
   };
 
   const handleFormInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSignInForm({ ...signinForm, [e.target.name]: e.target.value });
+    setPassResetForm({ ...passResetForm, [e.target.name]: e.target.value });
   };
 
   const handleError =
     (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) =>
     (msg: string) => {
-      return setSignInFormErrors({
-        ...signinFormErrors,
+      return setPassResetFormErrors({
+        ...passResetFormErrors,
         [e.target.name]: msg,
       });
     };
 
   return (
     <Box
-      data-testid='SignInTab'
+      data-testid='ResetPassTab'
       sx={{
         mx: 2,
         display: 'flex',
@@ -144,7 +129,7 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
         <LockOutlinedIcon />
       </Avatar>
       <Typography component='h1' variant='h5'>
-        Sign in
+        Reset Password
       </Typography>
       <Box
         component='form'
@@ -155,48 +140,23 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
         sx={{ mt: 1 }}
       >
         <TextField
-          name='userName'
-          margin='normal'
-          label='Username'
+          name='email'
+          label='Email Address'
           onChange={handleFormInput}
           fullWidth
           required
-          data-testid='userNameForm'
+          data-testid='resetField'
+          type='email'
           onBlur={(e) =>
             validateBlur(
-              /^[a-zA-Z0-9]+$/,
-              signinForm.userName,
+              /..*@(mail\.|alum\.){0,}utoronto.ca$/,
+              passResetForm.email,
               handleError(e),
-              'Please enter a valid username'
+              'Invalid email, only utoronto emails allowed'
             )
           }
-          error={signinFormErrors.userName !== ''}
-          helperText={signinFormErrors.userName}
-        />
-        <TextField
-          name='password'
-          margin='normal'
-          label='Password'
-          onChange={handleFormInput}
-          fullWidth
-          required
-          data-testid='passwordForm'
-          type='password'
-          onBlur={(e) =>
-            validateBlur(
-              /.{8,}/,
-              signinForm.password,
-              handleError(e),
-              'Ensure password is 8 characters or longer'
-            )
-          }
-          error={signinFormErrors.password !== ''}
-          helperText={signinFormErrors.password}
-        />
-        {/* will be implemented in future PR (after search) */}
-        <FormControlLabel
-          control={<Checkbox value='remember' color='primary' />}
-          label='Remember me'
+          error={passResetFormErrors.email !== ''}
+          helperText={passResetFormErrors.email}
         />
         <Button
           type='submit'
@@ -204,26 +164,17 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
           fullWidth
           sx={{ mt: 3, mb: 2 }}
         >
-          Sign In
+          Reset my password
         </Button>
         <Grid container>
-          <Grid item xs>
-            <Link
-              href='#'
-              variant='body2'
-              onClick={(e) => props.handleChange(e, 2)}
-            >
-              Forgot password?
-            </Link>
-          </Grid>
           <Grid item>
             <Link
               href='#'
               variant='body2'
-              onClick={(e) => props.handleChange(e, 1)}
-              data-testid='CreateAccountButton'
+              onClick={(e) => props.handleChange(e, 0)}
+              data-testid='resetPassButton'
             >
-              Don't have an account? Sign Up
+              Back to Sign In
             </Link>
           </Grid>
         </Grid>
@@ -232,4 +183,4 @@ function SignIn(props: { handleChange: Function; showAlert: Function }) {
   );
 }
 
-export default SignIn;
+export default PassReset;

--- a/client/src/containers/AuthContainer.test.tsx
+++ b/client/src/containers/AuthContainer.test.tsx
@@ -262,7 +262,7 @@ describe('signin component', () => {
         password: 'password',
       };
 
-      act(async () => {
+      await act(async () => {
         fireEvent.submit(form);
         await new Promise((r) => setTimeout(r, 1));
         expect(mockSignIn).toBeCalledWith(formData);

--- a/client/src/containers/AuthContainer.tsx
+++ b/client/src/containers/AuthContainer.tsx
@@ -17,6 +17,7 @@ import { useTheme } from '@mui/material/styles';
 
 import SignIn from '../components/SignIn';
 import SignUp from '../components/SignUp';
+import PassReset from '../components/PassReset';
 
 import './AuthContainer.css';
 
@@ -163,6 +164,9 @@ function AuthContainer() {
             </TabPanel>
             <TabPanel value={tabIndex} index={1}>
               <SignUp handleChange={handleChange} showAlert={showAlert} />
+            </TabPanel>
+            <TabPanel value={tabIndex} index={2}>
+              <PassReset handleChange={handleChange} showAlert={showAlert} />
             </TabPanel>
           </Box>
         </Grid>

--- a/client/src/containers/EmailConfirmContainer.test.tsx
+++ b/client/src/containers/EmailConfirmContainer.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import ServerApi from '../api/v1';
+import { EmailConfirmContainer } from '.';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...(jest.requireActual('react-router-dom') as any),
+  useNavigate: () => mockNavigate,
+  useLocation: () =>
+    jest.fn().mockReturnValue({ state: { from: { pathname: undefined } } }),
+}));
+
+global.window = Object.create(window);
+Object.defineProperty(window, 'location', {
+  value: {
+    search: undefined,
+  },
+  writable: true,
+});
+
+beforeEach(() => {
+  render(<EmailConfirmContainer />);
+});
+
+describe('email confirmation', () => {
+  describe('on error', () => {
+    it('should not confirm email if token is missing', async () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: '',
+        },
+      });
+      expect(window.location.search).toEqual('');
+
+      const form = screen.getByTestId('form');
+      const mockConfirmEmail = jest
+        .spyOn(ServerApi.prototype, 'confirmEmail')
+        .mockImplementation(() =>
+          Promise.resolve({ status: 204, data: { message: '' } })
+        );
+
+      // submit form and test
+      await act(async () => {
+        fireEvent.submit(form);
+        await new Promise((r) => setTimeout(r, 1));
+      });
+      expect(mockConfirmEmail).not.toBeCalled();
+    });
+  });
+
+  describe('on success', () => {
+    it('should confirm email if token is valid', async () => {
+      // set token in url
+      const token = '?c=token123';
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: token,
+        },
+      });
+      expect(window.location.search).toEqual(token);
+
+      const form = screen.getByTestId('form');
+      const mockResetPass = jest
+        .spyOn(ServerApi.prototype, 'confirmEmail')
+        .mockImplementation(() =>
+          Promise.resolve({ status: 204, data: { message: '' } })
+        );
+      const formData = {
+        token: 'token123',
+      };
+
+      // submit form and test
+      await act(async () => {
+        fireEvent.submit(form);
+        await new Promise((r) => setTimeout(r, 1));
+      });
+      expect(mockResetPass).toBeCalledWith(formData);
+    });
+  });
+});

--- a/client/src/containers/EmailConfirmContainer.tsx
+++ b/client/src/containers/EmailConfirmContainer.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect } from 'react';
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import Snackbar from '@mui/material/Snackbar';
+import Alert, { AlertColor } from '@mui/material/Alert';
+import { useNavigate } from 'react-router-dom';
+import ServerApi from '../api/v1';
+
+export default function EmailConfirmContainer() {
+  const api = new ServerApi();
+
+  const navigate = useNavigate();
+
+  const useAlert = (): [
+    { severity: string; message: string; display: boolean },
+    (type: string, message: string) => void,
+    () => void
+  ] => {
+    const [alert, setAlert] = useState({
+      severity: 'success',
+      message: '',
+      display: false,
+    });
+
+    const showAlert = (type: string, message: string) => {
+      setAlert({ severity: type, message: message, display: true });
+    };
+
+    const hideAlert = (event?: React.SyntheticEvent, reason?: string) => {
+      if (reason === 'clickaway') {
+        return;
+      }
+
+      setAlert({ ...alert, display: false });
+    };
+
+    return [alert, showAlert, hideAlert];
+  };
+
+  const [alert, showAlert, hideAlert] = useAlert();
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      hideAlert();
+    }, 6000);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  });
+
+  const getToken = () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const c = urlParams.get('c');
+
+    return c;
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const token = getToken();
+    if (!token) {
+      console.error('Missing token.');
+      navigate('/');
+      return;
+    }
+
+    try {
+      const { status, data } = await api.confirmEmail({ token: token });
+      if (status !== 204) {
+        if (!data) {
+          throw new Error('Missing error response.');
+        }
+        const msg = data.message;
+        console.error(msg);
+        showAlert('error', msg);
+      } else {
+        showAlert(
+          'success',
+          'Email has been confirmed! You may now close this tab.'
+        );
+        // navigate to a new page that displays this message instead of using alert
+      }
+    } catch (error) {
+      console.error(error);
+      showAlert(
+        'error',
+        'An error occurred while confirming your email. Please try again later.'
+      );
+    }
+  };
+
+  return (
+    <Container maxWidth='xs'>
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Snackbar open={alert.display} onClose={hideAlert}>
+          <Alert onClose={hideAlert} severity={alert.severity as AlertColor}>
+            <Typography sx={{ whiteSpace: 'pre-line' }}>
+              {alert.message}
+            </Typography>
+          </Alert>
+        </Snackbar>
+        <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
+          <LockOutlinedIcon />
+        </Avatar>
+        <Typography component='h1' variant='h5'>
+          Confirm email address
+        </Typography>
+        <Box
+          component='form'
+          onSubmit={handleSubmit}
+          noValidate
+          sx={{ mt: 1 }}
+          data-testid='form'
+        >
+          <Button
+            type='submit'
+            fullWidth
+            variant='contained'
+            sx={{ mt: 3, mb: 2 }}
+          >
+            Confirm email address
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/client/src/containers/PassResetContainer.test.tsx
+++ b/client/src/containers/PassResetContainer.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import ServerApi from '../api/v1';
+import { PassResetContainer } from '.';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...(jest.requireActual('react-router-dom') as any),
+  useNavigate: () => mockNavigate,
+  useLocation: () =>
+    jest.fn().mockReturnValue({ state: { from: { pathname: undefined } } }),
+}));
+
+global.window = Object.create(window);
+Object.defineProperty(window, 'location', {
+  value: {
+    search: undefined,
+  },
+  writable: true,
+});
+
+beforeEach(() => {
+  render(<PassResetContainer />);
+});
+
+describe('password reset', () => {
+  describe('on error', () => {
+    it('should not reset password if form is missing fields', () => {
+      const token = '?r=token123';
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: token,
+        },
+      });
+      expect(window.location.search).toEqual(token);
+
+      const form = screen.getByTestId('form');
+      const mockResetPass = jest
+        .spyOn(ServerApi.prototype, 'resetPass')
+        .mockImplementation();
+
+      fireEvent.submit(form);
+      expect(mockResetPass).not.toBeCalled();
+    });
+
+    it('should not reset password if fields are invalid', async () => {
+      const token = '?r=token123';
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: token,
+        },
+      });
+      expect(window.location.search).toEqual(token);
+
+      const form = screen.getByTestId('form');
+      const mockResetPass = jest
+        .spyOn(ServerApi.prototype, 'resetPass')
+        .mockImplementation();
+      const passwordForm = screen.getByTestId('password');
+
+      fireEvent.blur(passwordForm);
+      fireEvent.submit(form);
+
+      await new Promise((r) => setTimeout(r, 1));
+      expect(mockResetPass).not.toBeCalled();
+    });
+
+    it('should not reset pass if token is missing', async () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: '',
+        },
+      });
+      expect(window.location.search).toBe('');
+
+      // enter input into fields
+      const fields = {
+        password: 'password',
+        confirmPassword: 'password',
+      };
+      Object.keys(fields).forEach((key) => {
+        fireEvent.change(
+          screen.getByTestId(key).querySelector('input') as HTMLInputElement,
+          { target: { value: fields[key as keyof typeof fields] } }
+        );
+      });
+
+      const form = screen.getByTestId('form');
+      const mockResetPass = jest
+        .spyOn(ServerApi.prototype, 'resetPass')
+        .mockImplementation(() =>
+          Promise.resolve({ status: 204, data: { message: '' } })
+        );
+
+      // submit form and test
+      await act(async () => {
+        fireEvent.submit(form);
+        await new Promise((r) => setTimeout(r, 1));
+      });
+      expect(mockResetPass).not.toBeCalled();
+    });
+  });
+
+  describe('on success', () => {
+    it('should reset pass if fields and token are valid', async () => {
+      // set token in url
+      const token = '?r=token123';
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: token,
+        },
+      });
+      expect(window.location.search).toEqual(token);
+
+      // enter input into fields
+      const fields = {
+        password: 'password',
+        confirmPassword: 'password',
+      };
+      Object.keys(fields).forEach((key) => {
+        fireEvent.change(
+          screen.getByTestId(key).querySelector('input') as HTMLInputElement,
+          { target: { value: fields[key as keyof typeof fields] } }
+        );
+      });
+
+      const form = screen.getByTestId('form');
+      const mockResetPass = jest
+        .spyOn(ServerApi.prototype, 'resetPass')
+        .mockImplementation(() =>
+          Promise.resolve({ status: 204, data: { message: '' } })
+        );
+      const formData = {
+        token: 'token123',
+        password: 'password',
+        confirmPassword: 'password',
+      };
+
+      // submit form and test
+      await act(async () => {
+        fireEvent.submit(form);
+        await new Promise((r) => setTimeout(r, 1));
+      });
+      expect(mockResetPass).toBeCalledWith(formData);
+    });
+  });
+});

--- a/client/src/containers/PassResetContainer.tsx
+++ b/client/src/containers/PassResetContainer.tsx
@@ -1,0 +1,265 @@
+import React, { useState, useEffect } from 'react';
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import Snackbar from '@mui/material/Snackbar';
+import Alert, { AlertColor } from '@mui/material/Alert';
+import { useNavigate } from 'react-router-dom';
+import ServerApi from '../api/v1';
+
+export default function PassResetContainer() {
+  const api = new ServerApi();
+
+  const navigate = useNavigate();
+
+  const [passResetForm, setPassResetForm] = useState({ password: '' });
+  const [passResetFormErrors, setPassResetFormErrors] = useState({
+    password: '',
+  });
+
+  const [confirmPass, setConfirmPass] = useState('');
+  const [confirmPassError, setConfirmPassError] = useState('');
+
+  const useAlert = (): [
+    { severity: string; message: string; display: boolean },
+    (type: string, message: string) => void,
+    () => void
+  ] => {
+    const [alert, setAlert] = useState({
+      severity: 'success',
+      message: '',
+      display: false,
+    });
+
+    const showAlert = (type: string, message: string) => {
+      setAlert({ severity: type, message: message, display: true });
+    };
+
+    const hideAlert = (event?: React.SyntheticEvent, reason?: string) => {
+      if (reason === 'clickaway') {
+        return;
+      }
+
+      setAlert({ ...alert, display: false });
+    };
+
+    return [alert, showAlert, hideAlert];
+  };
+
+  const [alert, showAlert, hideAlert] = useAlert();
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      hideAlert();
+    }, 6000);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  });
+
+  const getToken = () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const r = urlParams.get('r');
+
+    return r;
+  };
+
+  const isFormMissingFields = () => {
+    for (const key in passResetForm) {
+      if (passResetForm[key as keyof typeof passResetForm] === '') {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const getErrorMessages = () => {
+    let msg = '';
+    for (const key in passResetFormErrors) {
+      const err = passResetFormErrors[key as keyof typeof passResetFormErrors];
+      msg += err === '' ? err : `${err}.\n`;
+    }
+    msg = msg.slice(0, -1);
+    return msg;
+  };
+
+  /**
+   * Validates all input forms except for `confirmPass` input
+   * @param regexPattern  pattern to match
+   * @param checkString   string to verify
+   * @param setHook       set function for the input's hook
+   * @param errorMessage  error message to display for that input field
+   */
+  const validateBlur = (
+    regexPattern: RegExp,
+    checkString: string,
+    setHook: Function,
+    errorMessage: string
+  ) => {
+    // only check for the confirm password field
+
+    if (!regexPattern.test(checkString)) {
+      setHook(errorMessage);
+    } else {
+      setHook('');
+    }
+  };
+
+  const validateConfirmPass = (): boolean => {
+    if (passResetForm.password !== confirmPass) {
+      const errMsg = 'Passwords must be matching';
+      setConfirmPassError(errMsg);
+      return false;
+    } else {
+      setConfirmPassError('');
+      return true;
+    }
+  };
+
+  const handleFormInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassResetForm({ ...passResetForm, [e.target.name]: e.target.value });
+  };
+
+  const handleError =
+    (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+    (msg: string) => {
+      return setPassResetFormErrors({
+        ...passResetFormErrors,
+        [e.target.name]: msg,
+      });
+    };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const token = getToken();
+    if (!token) {
+      console.error('Missing token.');
+      navigate('/');
+      return;
+    }
+
+    const msg = getErrorMessages();
+    if (msg !== '') {
+      console.warn(msg);
+      showAlert('warning', msg);
+      return;
+    }
+
+    if (isFormMissingFields()) {
+      const msg = 'Please fill in all the fields.';
+      console.warn(msg);
+      showAlert('warning', msg);
+      return;
+    }
+
+    try {
+      const { status, data } = await api.resetPass({
+        token: token,
+        ...passResetForm,
+        confirmPassword: confirmPass,
+      });
+      if (status !== 204) {
+        if (!data) {
+          throw new Error('Missing error response.');
+        }
+        const msg = data.message;
+        console.error(msg);
+        showAlert('error', msg);
+      } else {
+        showAlert(
+          'success',
+          'Password has been reset! You may now close this tab.'
+        );
+        // navigate to a new page that displays this message instead of using alert
+      }
+    } catch (error) {
+      console.error(error);
+      showAlert(
+        'error',
+        'An error occurred while resetting your password. Please try again later.'
+      );
+    }
+  };
+
+  return (
+    <Container maxWidth='xs'>
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Snackbar open={alert.display} onClose={hideAlert}>
+          <Alert onClose={hideAlert} severity={alert.severity as AlertColor}>
+            <Typography sx={{ whiteSpace: 'pre-line' }}>
+              {alert.message}
+            </Typography>
+          </Alert>
+        </Snackbar>
+        <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
+          <LockOutlinedIcon />
+        </Avatar>
+        <Typography component='h1' variant='h5'>
+          Create new password
+        </Typography>
+        <Box
+          component='form'
+          onSubmit={handleSubmit}
+          noValidate
+          sx={{ mt: 1 }}
+          data-testid='form'
+        >
+          <TextField
+            margin='normal'
+            required
+            fullWidth
+            name='password'
+            label='New Password'
+            type='password'
+            data-testid='password'
+            onChange={handleFormInput}
+            onBlur={(e) =>
+              validateBlur(
+                /.{8,}/,
+                passResetForm.password,
+                handleError(e),
+                'Ensure password is 8 characters or longer'
+              )
+            }
+            error={passResetFormErrors.password !== ''}
+            helperText={passResetFormErrors.password}
+          />
+          <TextField
+            margin='normal'
+            required
+            fullWidth
+            name='confirmPassword'
+            label='Confirm New Password'
+            type='password'
+            data-testid='confirmPassword'
+            onChange={(e) => setConfirmPass(e.target.value)}
+            onBlur={(e) => validateConfirmPass()}
+            error={confirmPassError !== ''}
+            helperText={confirmPassError}
+          />
+          <Button
+            type='submit'
+            fullWidth
+            variant='contained'
+            sx={{ mt: 3, mb: 2 }}
+          >
+            Create new password
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/client/src/containers/index.tsx
+++ b/client/src/containers/index.tsx
@@ -1,3 +1,5 @@
 import AuthContainer from './AuthContainer';
+import EmailConfirmContainer from './EmailConfirmContainer';
+import PassResetContainer from './PassResetContainer';
 
-export { AuthContainer };
+export { AuthContainer, EmailConfirmContainer, PassResetContainer };

--- a/server/controllers/v1/tests/user.test.ts
+++ b/server/controllers/v1/tests/user.test.ts
@@ -20,7 +20,7 @@ jest.mock('../../../services/emailService', () => {
     };
   });
 });
-const apiRoute = `${process.env.PAGE_URL}api/v1`;
+const baseRoute = `${process.env.PAGE_URL}`;
 
 const userRepo: typeof User = db.User;
 const EmailServiceMock = EmailService as jest.MockedClass<typeof EmailService>;
@@ -41,7 +41,7 @@ let signInDate: Date;
 
 beforeAll(async () => {
   await dbSync().catch((err) => fail(err));
-  uContr = new UserController(db.User, new EmailServiceMock(apiRoute));
+  uContr = new UserController(db.User, new EmailServiceMock(baseRoute));
 });
 
 beforeEach(async () => {
@@ -205,7 +205,8 @@ describe('v1 - User Controller', () => {
         fail('nullperson');
       }
 
-      expect(testPerson.confirmed).toBeFalsy();
+      testPerson.confirmed = true;
+      await testPerson.save();
       const status = await uContr.sendResetEmail(testPerson.email);
       await testPerson.reload();
       rawToken = testPerson.confirmationToken;

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  modulePathIgnorePatterns: ["build"]
 };
 
 require('dotenv').config();

--- a/server/server.ts
+++ b/server/server.ts
@@ -11,6 +11,12 @@ if (!process.env.JWT_SECRET) {
   throw new Error(err);
 }
 
+if (!process.env.PAGE_URL) {
+  const err = 'Missing page url';
+  console.error(err);
+  throw new Error(err);
+}
+
 const app = express();
 const port = 8080;
 
@@ -23,8 +29,9 @@ const noAuthPaths = [
   '/signin',
   '/signup',
   '/signout',
-  '/confirm',
-  '/password-reset',
+  '/request-password-reset',
+  '/confirm-email',
+  '/reset-password',
 ];
 app.use(
   auth(

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -1,9 +1,9 @@
 import sgMail from '@sendgrid/mail';
 export default class EmailService {
-  private apiRoute: string;
+  private baseRoute: string;
 
-  constructor(apiRoute: string) {
-    this.apiRoute = apiRoute;
+  constructor(baseRoute: string) {
+    this.baseRoute = baseRoute;
     sgMail.setApiKey(<string>process.env.SENDGRID_API);
   }
 
@@ -39,7 +39,7 @@ export default class EmailService {
     lastName: string,
     emailAddress: string
   ): Promise<boolean> {
-    const confirmURL = `${this.apiRoute}/users/confirm?c=${confToken}`; // this will be our route
+    const confirmURL = `${this.baseRoute}confirm-account?c=${confToken}`; // this will be our route
     const subjectLine = 'UBoard - Confirm your Email Address';
 
     const body = `Thank you for signing up to UBoard, ${firstName} ${lastName}.
@@ -63,7 +63,7 @@ export default class EmailService {
     userName: string,
     emailAddress: string
   ): Promise<boolean> {
-    const resetURL = `${this.apiRoute}/users/password-reset?r=${confToken}`;
+    const resetURL = `${this.baseRoute}password-reset?r=${confToken}`;
     const subjectLine = 'UBoard - Password Reset Requested';
     const body = `Hello,  ${firstName} ${lastName}.
         A password reset has been requested for the account with username: ${userName}. To reset your password, click the link below. 


### PR DESCRIPTION
…ssword reset container (#65)

* Create password reset page and integrate with api

* Revert emailService route changes

* Update email confirmation links

* Add client routes

* Add email confirmation container

* Temporarily disable handleSubmit

* Fix api integration

* Fix password reset handler

* Fix naming

* Fix pass reset email not sending

* Fix token validation

* Fix password reset handler

* Prevent reset if unconfirmed

* Remove comments

* Fix emailservice parameter and update tests

* Disable "Remember me" button temporarily

* Format with prettier

* Address PR comments

* Add tests for pass reset and email confirm

* Update readme